### PR TITLE
feat: update ikvmc to 8.2.1

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -79,12 +79,11 @@ let restoreFolderFromFile folder zipFile =
         zipFile |> unZipTo folder
 
 // Location of IKVM Compiler
-let ikvmVersion = @"8.2.0-prerelease.392"
 let ikvmRootFolder = root </> "paket-files" </> "github.com"
 
-let ikvmcFolder_NetFramework = ikvmRootFolder </> "ikvm-" + ikvmVersion + "-tools-net461-win7-x64"
-let ikvmcFolder_NetCore_Windows = ikvmRootFolder </> "ikvm-" + ikvmVersion + "-tools-net461-win7-x64"
-let ikvmcFolder_NetCore_Linux = ikvmRootFolder </> "ikvm-" + ikvmVersion + "-tools-net461-linux-x64"
+let ikvmcFolder_NetFramework = ikvmRootFolder </> "win7-x64" // bug? should be "any"
+let ikvmcFolder_NetCore_Windows = ikvmRootFolder </> "win7-x64"
+let ikvmcFolder_NetCore_Linux = ikvmRootFolder </> "linux-x64"
 
 let ikvmcExe_NetFramework = ikvmcFolder_NetFramework </> "ikvmc.exe"
 let ikvmcExe_NetCore_Windows = ikvmcFolder_NetCore_Windows </> "ikvmc.exe"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.300",
+    "version": "6.0.302",
     "rollForward": "latestFeature"
   }
 }

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,15 +1,14 @@
 source https://nuget.org/api/v2
 source https://api.nuget.org/v3/index.json
 
-nuget IKVM 8.2.0-prerelease0392
+nuget IKVM
 nuget NUnit
 nuget NUnit3TestAdapter
 nuget Microsoft.NET.Test.Sdk
 nuget Microsoft.NETFramework.ReferenceAssemblies
 
-http https://github.com/ikvm-revived/ikvm/releases/download/8.2.0-prerelease.392/IKVM-8.2.0-prerelease.392-tools-net461-any.zip ikvm-8.2.0-prerelease.392-tools-net461-win7-x64/tools.zip
-http https://github.com/ikvm-revived/ikvm/releases/download/8.2.0-prerelease.392/IKVM-8.2.0-prerelease.392-tools-netcoreapp3.1-win7-x64.zip ikvm-8.2.0-prerelease.392-tools-netcoreapp3.1-linux-x64/tools.zip
-http https://github.com/ikvm-revived/ikvm/releases/download/8.2.0-prerelease.392/IKVM-8.2.0-prerelease.392-tools-netcoreapp3.1-linux-x64.zip ikvm-8.2.0-prerelease.392-tools-netcoreapp3.1-win7-x64/tools.zip
+http https://github.com/ikvm-revived/ikvm/releases/download/8.2.1/IKVM-8.2.1-tools-ikvmc-net461.zip
+http https://github.com/ikvm-revived/ikvm/releases/download/8.2.1/IKVM-8.2.1-tools-ikvmc-netcoreapp3.1.zip
 
 http https://archive.apache.org/dist/opennlp/opennlp-1.9.1/apache-opennlp-1.9.1-bin.zip
 

--- a/paket.lock
+++ b/paket.lock
@@ -1,6 +1,6 @@
 NUGET
   remote: https://www.nuget.org/api/v2
-    IKVM (8.2.0-prerelease0392)
+    IKVM (8.2.1)
       Microsoft.Extensions.DependencyModel (>= 6.0) - restriction: >= netcoreapp3.1
       Microsoft.Win32.Registry (>= 5.0) - restriction: >= netcoreapp3.1
       SharpZipLib (>= 1.3.3) - restriction: || (>= net461) (>= netcoreapp3.1)
@@ -9,7 +9,7 @@ NUGET
       System.Drawing.Common (>= 6.0) - restriction: >= netcoreapp3.1
       System.IO.Compression (>= 4.3) - restriction: >= netcoreapp3.1
       System.IO.FileSystem.AccessControl (>= 5.0) - restriction: >= netcoreapp3.1
-      System.Memory (>= 4.5.4) - restriction: || (>= net461) (>= netcoreapp3.1)
+      System.Memory (>= 4.5.5) - restriction: || (>= net461) (>= netcoreapp3.1)
       System.Runtime (>= 4.3.1) - restriction: >= netcoreapp3.1
       System.Runtime.InteropServices (>= 4.3) - restriction: >= netcoreapp3.1
       System.Runtime.Loader (>= 4.3) - restriction: >= netcoreapp3.1
@@ -33,7 +33,7 @@ NUGET
       System.ComponentModel.Primitives (>= 4.1) - restriction: >= uap10.0
       System.ComponentModel.TypeConverter (>= 4.1) - restriction: >= uap10.0
       System.Runtime.InteropServices.RuntimeInformation (>= 4.0) - restriction: >= uap10.0
-    Microsoft.NETCore.Platforms (6.0.3) - restriction: || (&& (< monoandroid) (>= netcoreapp1.0) (< netcoreapp2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netcoreapp3.1) (< netstandard1.2)) (&& (< monoandroid) (>= netcoreapp3.1) (< netstandard1.3)) (&& (< monoandroid) (>= netcoreapp3.1) (< netstandard1.5)) (&& (< net35) (>= netstandard2.0)) (>= netcoreapp2.0) (&& (>= netcoreapp3.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< netstandard1.0) (>= netstandard2.0) (>= win8)) (&& (< netstandard1.3) (>= netstandard2.0) (< win8) (>= wpa81)) (&& (< netstandard1.5) (>= netstandard2.0) (>= uap10.0)) (&& (>= netstandard2.0) (>= uap10.1)) (&& (>= netstandard2.0) (>= wp8))
+    Microsoft.NETCore.Platforms (6.0.5) - restriction: || (&& (< monoandroid) (>= netcoreapp1.0) (< netcoreapp2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netcoreapp3.1) (< netstandard1.2)) (&& (< monoandroid) (>= netcoreapp3.1) (< netstandard1.3)) (&& (< monoandroid) (>= netcoreapp3.1) (< netstandard1.5)) (&& (< net35) (>= netstandard2.0)) (>= netcoreapp2.0) (&& (>= netcoreapp3.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< netstandard1.0) (>= netstandard2.0) (>= win8)) (&& (< netstandard1.3) (>= netstandard2.0) (< win8) (>= wpa81)) (&& (< netstandard1.5) (>= netstandard2.0) (>= uap10.0)) (&& (>= netstandard2.0) (>= uap10.1)) (&& (>= netstandard2.0) (>= wp8))
     Microsoft.NETCore.Targets (5.0) - restriction: || (&& (< monoandroid) (>= netcoreapp1.0) (< netcoreapp2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netcoreapp3.1) (< netstandard1.2)) (&& (< monoandroid) (>= netcoreapp3.1) (< netstandard1.3)) (&& (< monoandroid) (>= netcoreapp3.1) (< netstandard1.5)) (&& (>= netcoreapp3.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
     Microsoft.NETFramework.ReferenceAssemblies (1.0.2)
       Microsoft.NETFramework.ReferenceAssemblies.net20 (>= 1.0.2) - restriction: && (>= net20) (< net35)
@@ -94,7 +94,7 @@ NUGET
       System.Runtime.Serialization.Formatters (>= 4.3) - restriction: && (< net20) (>= netstandard1.3) (< netstandard2.0)
       System.Runtime.Serialization.Primitives (>= 4.3) - restriction: || (&& (< net20) (>= netstandard1.0) (< netstandard1.3)) (&& (< net20) (>= netstandard1.3) (< netstandard2.0))
       System.Xml.XmlDocument (>= 4.3) - restriction: && (< net20) (>= netstandard1.3) (< netstandard2.0)
-    NuGet.Frameworks (6.2) - restriction: || (&& (>= net45) (>= netcoreapp1.0) (< netstandard1.3)) (&& (>= net451) (>= netcoreapp1.0)) (&& (>= netcoreapp1.0) (< netstandard2.0)) (>= netcoreapp2.1)
+    NuGet.Frameworks (6.2.1) - restriction: || (&& (>= net45) (>= netcoreapp1.0) (< netstandard1.3)) (&& (>= net451) (>= netcoreapp1.0)) (&& (>= netcoreapp1.0) (< netstandard2.0)) (>= netcoreapp2.1)
     NUnit (3.13.3)
       NETStandard.Library (>= 2.0) - restriction: && (< net35) (>= netstandard2.0)
     NUnit3TestAdapter (4.2.1)
@@ -295,7 +295,7 @@ NUGET
       System.Text.Encoding (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
     System.Text.Encodings.Web (6.0) - restriction: >= netcoreapp3.1
       System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
-    System.Text.Json (6.0.4) - restriction: >= netcoreapp3.1
+    System.Text.Json (6.0.5) - restriction: >= netcoreapp3.1
       System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
       System.Text.Encodings.Web (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
     System.Threading (4.3) - restriction: || (&& (< monoandroid) (>= netcoreapp1.0) (< netcoreapp2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netcoreapp3.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< netstandard2.0) (>= uap10.0))
@@ -330,9 +330,8 @@ NUGET
       System.Xml.ReaderWriter (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
 HTTP
   remote: https://github.com
-    ikvm-8.2.0-prerelease.392-tools-net461-win7-x64/tools.zip (/ikvm-revived/ikvm/releases/download/8.2.0-prerelease.392/IKVM-8.2.0-prerelease.392-tools-net461-any.zip)
-    ikvm-8.2.0-prerelease.392-tools-netcoreapp3.1-linux-x64/tools.zip (/ikvm-revived/ikvm/releases/download/8.2.0-prerelease.392/IKVM-8.2.0-prerelease.392-tools-netcoreapp3.1-win7-x64.zip)
-    ikvm-8.2.0-prerelease.392-tools-netcoreapp3.1-win7-x64/tools.zip (/ikvm-revived/ikvm/releases/download/8.2.0-prerelease.392/IKVM-8.2.0-prerelease.392-tools-netcoreapp3.1-linux-x64.zip)
+    IKVM-8.2.1-tools-ikvmc-net461.zip (/ikvm-revived/ikvm/releases/download/8.2.1/IKVM-8.2.1-tools-ikvmc-net461.zip)
+    IKVM-8.2.1-tools-ikvmc-netcoreapp3.1.zip (/ikvm-revived/ikvm/releases/download/8.2.1/IKVM-8.2.1-tools-ikvmc-netcoreapp3.1.zip)
   remote: https://archive.apache.org
     apache-opennlp-1.9.1-bin.zip (/dist/opennlp/opennlp-1.9.1/apache-opennlp-1.9.1-bin.zip)
   remote: http://opennlp.sourceforge.net


### PR DESCRIPTION
Why latest `ikvmc` 8.2.1 fails to compile jars?
@NightOwl888 can you please help me understand what is wrong? Am I using wrong zips?

<img width="1139" alt="image" src="https://user-images.githubusercontent.com/1197905/182715067-cac32f50-2d37-4a9d-a77d-4a200ea15e2f.png">

Update: this is PR with CI enabled - https://github.com/sergey-tihon/OpenNLP.NET/pull/16. [Error is the same](https://github.com/sergey-tihon/OpenNLP.NET/runs/7661435006?check_suite_focus=true#step:7:139)

```
"D:\a\OpenNLP.NET\OpenNLP.NET\paket-files\github.com\win7-x64\ikvmc.exe"  -version:1.9.1.2 D:\a\OpenNLP.NET\OpenNLP.NET\paket-files/archive.apache.org/apache-opennlp-1.9.1/lib\aopalliance-repackaged-2.5.0-b30.jar -out:aopalliance-repackaged-2.5.0-b30.dll -keyfile:OpenNLP.snk (In: false, Out: false, Err: false)
IKVM.NET Compiler (8.2.1+Branch.main.Sha.e85684966cf595d7942d6930fda9c27d23b509e1)
Copyright © 2022 Jeroen Frijters, Windward Studios, Jerome Haltom, Shad Storhaug


*** INTERNAL COMPILER ERROR ***

PLEASE FILE A BUG REPORT FOR IKVM.NET WHEN YOU SEE THIS MESSAGE

ikvmc, Version=8.2.0.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58
D:\a\OpenNLP.NET\OpenNLP.NET\paket-files\github.com\win7-x64\
3.1.27 64-bit

System.IO.FileNotFoundException: netstandard
   at IKVM.Reflection.Universe.Load(String refname, Module requestingModule, Boolean throwOnError) in D:\a\ikvm\ikvm\src\IKVM.Reflection\Universe.cs:line 789
   at IKVM.Internal.AssemblyResolver.Init(Universe universe, Boolean nostdlib, IList`1 references, IList`1 userLibPaths) in D:\a\ikvm\ikvm\src\ikvmc\IKVM\Internal\AssemblyResolver.cs:line 93
   at ikvmc.IkvmcCompiler.Compile(String[] args) in D:\a\ikvm\ikvm\src\ikvmc\IkvmcCompiler.cs:line 178
   at ikvmc.IkvmcCompiler.Main(String[] args) in D:\a\ikvm\ikvm\src\ikvmc\IkvmcCompiler.cs:line 112
```
